### PR TITLE
 forward info on fail

### DIFF
--- a/lib/strategy.js
+++ b/lib/strategy.js
@@ -31,7 +31,7 @@ Strategy.prototype.authenticate = function(req) {
 
   function verified(err, client, info) {
     if (err) { return self.error(err); }
-    if (!client) { return self.fail(); }
+    if (!client) { return self.fail(info); }
     
     info = info || {};
     info.unauthenticated = true;


### PR DESCRIPTION
Forwarding the `info` let the consumer pass the `challenge` that passport library supports.